### PR TITLE
🛡️ Sentinel: [Medium] Fix swallowed background job errors in purge script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2026-03-11: [Medium] Swallowing background job errors with `wait -n` masks downstream failures; capture and check exit codes explicitly.

--- a/the-purge.sh
+++ b/the-purge.sh
@@ -1,3 +1,7 @@
+function reportError() {
+  echo "::error::$1" >&2
+}
+
 #doc: Docker
 
 {
@@ -187,4 +191,15 @@ stuffToDelete+=(
 sudo systemctl stop "${stuffToStop[@]}" &
 sudo rm -rf "${stuffToDelete[@]}" &
 
-while wait -n; do : ; done; # wait until it's possible to wait for bg job
+FAIL=0
+for job in $(jobs -p); do
+    wait "$job" || {
+        reportError "Background job $job failed in the-purge.sh"
+        FAIL=$((FAIL + 1))
+    }
+done
+
+if [ "$FAIL" -gt 0 ]; then
+    reportError "$FAIL background jobs failed during the purge."
+    exit 1
+fi


### PR DESCRIPTION
🛡️ Sentinel: [Medium] Fix swallowed background job errors in purge script

## Vulnerability
**Severity:** Medium
**Vulnerability:** Ignored/swallowed errors in `the-purge.sh` background cleanup jobs.
**Impact:** Silent failures during the cleanup phase (e.g., permission denied or missing package errors) would be masked because `wait -n` ignored exit codes. This masks downstream vulnerabilities and fails open instead of failing securely.

## Fix
- Implemented a centralized `reportError` function as mandated.
- Refactored the wait loop to capture the exit status of all background jobs.
- If any job fails, the action outputs the error and exits with a non-zero code to ensure the workflow step properly fails.

## Verification
- Validated syntax using `bash -n`.
- Ensured scope correctly applies to only `the-purge.sh` and the journal `.jules/sentinel.md`.
- No temporary or bootstrap files are included in the commit.

---

### Assumptions
- Background cleanup jobs that fail indicate a serious problem with the system state and should stop the entire workflow.
- Standard GitHub Actions `::error::` format is the expected way to "funnel through a single centralized reporting function" for this repo context since it doesn't use Sentry or complex utilities.

### Alternatives Not Chosen
- Adding `set -e` inside the background jobs. This wouldn't solve the wait issue directly, as bash handles background job exit codes differently, and the main thread still needs to check them.
- Abstracting the error handler into a separate sourced file. The project currently has zero dependencies, and the `reportError` is tiny enough (3 lines) to be included inline, keeping `the-purge.sh` self-contained.

### How To Pivot
- If you prefer to log but continue on error, remove `exit 1` in the final block and only leave the `reportError` call.

### Next Knobs
- **Failure Threshold:** The variable `FAIL` can be used to tolerate up to $N$ errors before hard failing.
- **Error Verbosity:** Can add stack traces or more context into `reportError` if standard `::error::` isn't enough.

---
*PR created automatically by Jules for task [7306270485682830473](https://jules.google.com/task/7306270485682830473) started by @lucasew*