### PR TITLE
📝 Docs: Improve documentation for action scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Project Conventions for AI Agents
+
+Welcome to `action-i-only-care-about-nix`. When making PRs or editing files in this repository, follow these rules and operational memory items.
+
+## Operational Memory
+
+* `.github/workflows/` -> Holds CI/CD scripts
+* `action.yml` -> Entrypoint for the Github Action
+* `the-purge.sh` -> Script responsible for removing large, unnecessary pre-installed packages on standard GitHub runners.
+* `mountpoint-fusion.sh` -> Script responsible for taking leftover disk space across standard mounts and converting them to a fast `BTRFS` RAID0 partition mounted at `/state`.
+
+## Core Guidelines
+
+* **Repository purpose**: GitHub Action that clears GitHub Actions VM disk space and mounts a fast BTRFS RAID0 partition on '/state' for Nix using bash scripts.
+* **Mise First**: Always install and use 'mise' for task execution, and strictly pin tool versions. Don't downgrade anything unless asked.
+* **Error Reporting**: Error handling must funnel through a single centralized reporting function. Silent failures and empty catch blocks are strictly prohibited.
+* **Staging Limits**: Stage files explicitly with 'git add <path>'. Never use 'git add .'. Never commit bootstrap/download/tooling artifacts (e.g., 'install-mise.sh').
+* **Ignore Lists**: Always check '.jules/CONSISTENTLY_IGNORED.md' (if it exists) before planning tasks to avoid repeating rejected patterns.
+
+## Agent-Specific Conventions
+
+* **Docs (📝)**: PR titles must exactly match the format '📝 Docs: [Description]'.
+* **Sentinel (🛡️)**: PR titles must exactly match '🛡️ Sentinel: [Severity] [Description]', and fixes must be appended to '.jules/sentinel.md' as a single-line learning pattern.
+* **Mandatory PR Sections**: Every Pull Request must include exactly four mandatory sections: 'Assumptions', 'Alternatives Not Chosen', 'How To Pivot', and 'Next Knobs'.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
 # action-i-only-care-about-nix
-Cleans the crap out of a GitHub Actions workflow so the most space possible is available for Nix
 
-Just add and enjoy. The merged partition mountpoint is mounted on /state so create bind mounts for additional dirs if you want to use it for more stuff.
+Cleans the pre-installed software out of a GitHub Actions workflow environment so the most disk space possible is available for Nix builds.
+
+## How it works
+1. **The Purge (`the-purge.sh`)**: Aggressively uninstalls pre-installed tools (Docker, Snap, large SDKs in `/usr/local` and `/opt`) running in the background for speed.
+2. **Mountpoint Fusion (`mountpoint-fusion.sh`)**: Takes the remaining space on the root `/` and `/mnt` partitions, loopback-mounts them into image files, and creates a high-performance BTRFS RAID0 filesystem mounted at `/state`.
+
+## Usage
+
+Just add it as a step in your workflow:
+
+```yaml
+steps:
+  - uses: lucasew/action-i-only-care-about-nix@vX
+```
+
+By default, `/nix` is already bind-mounted into `/state/nix`.
+
+### Additional Directories
+
+The merged high-speed partition is mounted on `/state`. If you want to use it for more things beyond Nix, you can create bind mounts from `/state` to the directories you need:
+
+```bash
+sudo mkdir -p /state/my-cache /my-cache
+sudo mount -o bind /state/my-cache /my-cache
+```

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,7 @@ runs:
         sudo df -h
     - name: Start the purge
       shell: bash
+      # Executes the-purge.sh to remove unneeded pre-installed software, maximizing available disk space.
       run: ${{ github.action_path }}/the-purge.sh
     - name: Check disk usage after cleanup
       shell: bash
@@ -20,6 +21,7 @@ runs:
         sudo df -h
     - name: Setup BTRFS join
       shell: bash
+      # Executes mountpoint-fusion.sh to combine the remaining space on / and /mnt into a fast BTRFS RAID0 partition at /state.
       run: ${{ github.action_path }}/mountpoint-fusion.sh
     - name: Check disk usage after BTRFS setup
       shell: bash

--- a/mountpoint-fusion.sh
+++ b/mountpoint-fusion.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
+#
+# mountpoint-fusion.sh
+# Combines remaining free space on the root (/) and /mnt partitions
+# into a single fast BTRFS RAID0 partition mounted at /state.
+# Designed to be fast and ephemeral (data safety is not a priority).
 
 set -eu
 
-# sudo dmesg -w &
+# A simple wrapper to echo and execute commands for logging
 function run {
   echo "run:" "$@"
   "$@"
@@ -13,6 +18,8 @@ mnt_free_space=$(df -m /mnt | tail -n 1 | awk '{print $4}')
 echo "free space of /: ${root_free_space}MB"
 echo "free space of /mnt: ${mnt_free_space}MB"
 
+# Reserve 1GB of overhead for each partition and create large image files.
+# Loop devices are used to map these files as block devices for BTRFS.
 loops=()
 if run sudo fallocate -l $((root_free_space - 1024))M /disk.img; then
   run sudo losetup /dev/loop69 /disk.img
@@ -26,6 +33,7 @@ fi
 
 
 # fvck reliability, gotta go fast
+# Uses RAID0 over the loopback devices to maximize throughput and space.
 run sudo mkfs.btrfs -L actions -d raid0 -m raid0 "${loops[@]}"
 run sudo btrfs device scan
 
@@ -34,8 +42,10 @@ run sudo btrfs filesystem show
 run sudo file "${loops[@]}"
 
 run sudo mkdir -p /state
+# Mount with aggressive caching/performance flags (nobarrier, high commit interval) since data loss on panic is acceptable for CI.
 run sudo mount LABEL=actions /state -o defaults,noautodefrag,nobarrier,commit=300,compress=zstd
 
+# Bind-mount specific high-use directories into the fast BTRFS /state partition.
 for dir in /nix; do
   echo "Bind mounting $dir"
   run sudo mkdir -p {/state,}$dir

--- a/the-purge.sh
+++ b/the-purge.sh
@@ -1,12 +1,18 @@
-#doc: Docker
+#!/usr/bin/env bash
+#
+# the-purge.sh
+# Purges pre-installed software from the GitHub Actions runner to maximize disk space.
+# Uses background jobs (&) extensively to parallelize deletion for speed.
 
+#doc: Docker
+# Remove all docker images and prune system to free up space. Runs in the background.
 {
 docker image rm $(docker image ls --format '{{.ID}}')
 docker system prune --all --force
 } &
 
 #doc: Get rid of snap once and for all (~1GB)
-
+# Pin snapd to a very low priority to ensure it isn't accidentally reinstalled.
 sudo cat <<EOF | sudo tee /etc/apt/preferences.d/nosnap.pref
   Package: snapd
   Pin: release a=*
@@ -184,7 +190,9 @@ stuffToDelete+=(
 ~/.dotnet # (~50MB)
 )
 
+# Stop services and delete directories in parallel
 sudo systemctl stop "${stuffToStop[@]}" &
 sudo rm -rf "${stuffToDelete[@]}" &
 
+# Wait for all background jobs (docker prune, services stop, rm -rf) to finish before exiting
 while wait -n; do : ; done; # wait until it's possible to wait for bg job


### PR DESCRIPTION
### Assumptions
- It's safe to add inline comments to bash files without affecting their execution.
- BTRFS flags (e.g. `noautodefrag,nobarrier`) are intentionally optimized for performance over durability in this ephemeral CI environment.
- The user's system instructions supersede any pre-existing project memory (and I should codify those instructions into an `AGENTS.md` file).

### Alternatives Not Chosen
- Skipping `the-purge.sh` and `mountpoint-fusion.sh` because they are `.sh` and not standard documentation files. Chosen not to because the prompt states to explain the *why*, *nuances*, and *flow* of the codebase, which live in these files.
- Adding extensive docstrings to every bash function. Chosen not to because the prompt enforces "Essentialism" and "NO OBVIOUS COMMENTS".

### How To Pivot
- If the BTRFS explanation is incorrect or `AGENTS.md` should not be checked into the repo, drop the `AGENTS.md` file and remove the comments from `mountpoint-fusion.sh` with a simple Git revert.

### Next Knobs
- Adjust the text in the `README.md` to be more or less aggressive about the word "crap".
- Modify the project rules in `AGENTS.md` to add custom linters or stricter rules.
- Tweak the high-level explanations in `action.yml`.

---
*PR created automatically by Jules for task [7920570720291413039](https://jules.google.com/task/7920570720291413039) started by @lucasew*