### PR TITLE
🛠️ Refactor: Code structure, method extraction, and centralized error handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,14 @@ runs:
         sudo df -h
     - name: Start the purge
       shell: bash
-      run: ${{ github.action_path }}/the-purge.sh
+      run: ${{ github.action_path }}/src/the-purge.sh
     - name: Check disk usage after cleanup
       shell: bash
       run: |
         sudo df -h
     - name: Setup BTRFS join
       shell: bash
-      run: ${{ github.action_path }}/mountpoint-fusion.sh
+      run: ${{ github.action_path }}/src/mountpoint-fusion.sh
     - name: Check disk usage after BTRFS setup
       shell: bash
       run: |

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tasks.test]
+run = "bash -n src/*.sh"
+
+[tasks.ci]
+run = "mise run test"

--- a/src/error_handler.sh
+++ b/src/error_handler.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function report_error {
+  local error_msg="$1"
+  # Provide context with stack trace if possible
+  echo "::error::[action-i-only-care-about-nix] $error_msg" >&2
+}
+
+# Trap common errors globally if sourced
+trap 'report_error "An unexpected error occurred in script: $0 at line $LINENO"' ERR

--- a/src/mountpoint-fusion.sh
+++ b/src/mountpoint-fusion.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
+source "$(dirname "$0")/error_handler.sh"
 
 # sudo dmesg -w &
 function run {
   echo "run:" "$@"
-  "$@"
+  "$@" || {
+    report_error "Command failed: $*"
+    return 1
+  }
 }
 
 root_free_space=$(df -m / | tail -n 1 | awk '{print $4}')

--- a/src/mountpoint-fusion.sh
+++ b/src/mountpoint-fusion.sh
@@ -42,6 +42,6 @@ run sudo mount LABEL=actions /state -o defaults,noautodefrag,nobarrier,commit=30
 
 for dir in /nix; do
   echo "Bind mounting $dir"
-  run sudo mkdir -p {/state,}$dir
+  run sudo mkdir -p "/state$dir" "$dir"
   run sudo mount -o bind "/state$dir" "$dir"
 done

--- a/src/the-purge.sh
+++ b/src/the-purge.sh
@@ -1,36 +1,42 @@
-#doc: Docker
+#!/usr/bin/env bash
 
-{
-docker image rm $(docker image ls --format '{{.ID}}')
-docker system prune --all --force
-} &
+set -euo pipefail
+source "$(dirname "$0")/error_handler.sh"
 
-#doc: Get rid of snap once and for all (~1GB)
+function purge_docker() {
+  #doc: Docker
+  {
+  docker image rm $(docker image ls --format '{{.ID}}') || report_error "Failed to remove Docker images"
+  docker system prune --all --force || report_error "Failed to prune Docker system"
+  } &
+}
 
-sudo cat <<EOF | sudo tee /etc/apt/preferences.d/nosnap.pref
+function purge_snap() {
+  #doc: Get rid of snap once and for all (~1GB)
+  sudo cat <<EOF | sudo tee /etc/apt/preferences.d/nosnap.pref > /dev/null
   Package: snapd
   Pin: release a=*
   Pin-Priority: -10
 EOF
 
-sudo systemctl stop snapd.service
-sudo umount --recursive /snap/*/*
-sudo rm -rf  ~/snap /snap /var/snap /var/lib/snapd /usr/lib/snapd
+  sudo systemctl stop snapd.service || report_error "Failed to stop snapd"
+  sudo umount --recursive /snap/*/* || true
+  sudo rm -rf ~/snap /snap /var/snap /var/lib/snapd /usr/lib/snapd || report_error "Failed to remove snap files"
+}
 
-stuffToStop=()
-stuffToDelete=()
+function stop_services() {
+  local stuffToStop=(
+    mono-xsp4.service
+    rsyslog.service
+    chrony.service
+    php8.1-fpm.service
+  )
+  #doc: Stop services
+  sudo systemctl stop "${stuffToStop[@]}" &
+}
 
-#doc: Stop services
-
-stuffToStop+=(
-  mono-xsp4.service
-  rsyslog.service
-  chrony.service
-  php8.1-fpm.service
-)
-
-
-stuffToDelete+=(
+function remove_files() {
+  local stuffToDelete=(
 #doc: Remove unnecessary stuff in /opt (~11GB)
 
 /opt/hostedtoolcache
@@ -182,9 +188,13 @@ stuffToDelete+=(
 ~/.rustup # (~500MB)
 ~/.cargo # (~250MB)
 ~/.dotnet # (~50MB)
-)
+  )
+  sudo rm -rf "${stuffToDelete[@]}" &
+}
 
-sudo systemctl stop "${stuffToStop[@]}" &
-sudo rm -rf "${stuffToDelete[@]}" &
+purge_docker
+purge_snap
+stop_services
+remove_files
 
 while wait -n; do : ; done; # wait until it's possible to wait for bg job

--- a/src/the-purge.sh
+++ b/src/the-purge.sh
@@ -6,7 +6,12 @@ source "$(dirname "$0")/error_handler.sh"
 function purge_docker() {
   #doc: Docker
   {
-  docker image rm $(docker image ls --format '{{.ID}}') || report_error "Failed to remove Docker images"
+  local images
+  images=$(docker image ls --format '{{.ID}}')
+  if [ -n "$images" ]; then
+    # shellcheck disable=SC2086
+    docker image rm $images || report_error "Failed to remove Docker images"
+  fi
   docker system prune --all --force || report_error "Failed to prune Docker system"
   } &
 }
@@ -19,7 +24,7 @@ function purge_snap() {
   Pin-Priority: -10
 EOF
 
-  sudo systemctl stop snapd.service || report_error "Failed to stop snapd"
+  sudo systemctl stop snapd.service || true
   sudo umount --recursive /snap/*/* || true
   sudo rm -rf ~/snap /snap /var/snap /var/lib/snapd /usr/lib/snapd || report_error "Failed to remove snap files"
 }
@@ -32,7 +37,7 @@ function stop_services() {
     php8.1-fpm.service
   )
   #doc: Stop services
-  sudo systemctl stop "${stuffToStop[@]}" &
+  sudo systemctl stop "${stuffToStop[@]}" || true
 }
 
 function remove_files() {
@@ -189,12 +194,13 @@ function remove_files() {
 ~/.cargo # (~250MB)
 ~/.dotnet # (~50MB)
   )
-  sudo rm -rf "${stuffToDelete[@]}" &
+  sudo rm -rf "${stuffToDelete[@]}" || report_error "Failed to remove files"
 }
 
 purge_docker
 purge_snap
-stop_services
-remove_files
+
+{ stop_services; } &
+remove_files &
 
 while wait -n; do : ; done; # wait until it's possible to wait for bg job


### PR DESCRIPTION
### Assumptions
- The primary operations performed by `the-purge.sh` (Docker cleanup, Snap removal, stopping services, file deletion) can run sequentially or as isolated background processes without introducing race conditions where none existed previously.
- Using `set -euo pipefail` alongside an `ERR` trap does not break legacy background commands so long as common failures (e.g. `docker image rm` failing) are caught using `|| report_error`.
- BTRFS utilities referenced in `mountpoint-fusion.sh` remain system tools requiring root and will be executed properly by the action runner with standard variables.

### Alternatives Not Chosen
- **Complete Rewrite into a Compiled Language / TypeScript:** This action relies heavily on low-level shell commands and package managers specific to Ubuntu/Linux Actions runners. Rewriting would add build complexity and external dependencies without clear performance gains.
- **Grouping scripts by file-type (`scripts/`):** The `src/` directory pattern was selected because the bash scripts represent the actual source code logic of the Action, rather than just supplementary tooling.

### How To Pivot
- If the new function extractions inside `the-purge.sh` interfere with global context variables or variable masking in Actions, revert the function declarations to the previous flat script flow. You can remove `set -euo pipefail` if it triggers on historically ignored exit codes.
- To rollback the directory changes, move the `.sh` files back to the root level and revert the `run: ${{ github.action_path }}/src/...` paths in `action.yml` back to `${{ github.action_path }}/...`.

### Next Knobs
- **`src/error_handler.sh`:** Contains the formatting string for GitHub Actions logging (`::error::`). You can update this to log to a file or an external system if needed.
- **`mise.toml`:** The `test` task runs simple `bash -n`. You can enhance this with `shellcheck` or `bats` by adding tools and updating the `[tasks.test]` definition.
- **`src/the-purge.sh` - `remove_files()`:** The array `stuffToDelete` holds all the paths for deletion. You can modify this block directly to stop removing certain tools like .NET or Android if user workflows require them.

---
*PR created automatically by Jules for task [7605431284661034424](https://jules.google.com/task/7605431284661034424) started by @lucasew*